### PR TITLE
fix: add authtokens dir to Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,14 @@ RUN apt-get update \
     && apt-get install -y graphicsmagick \
     && apt-get clean
 
+RUN mkdir -p /app/credentials /app/instances /app/logs /app/maps /app/authtokens \
+    && chown -R node:node /app/credentials /app/instances /app/logs /app/maps /app/authtokens
+
 VOLUME [ "/app/credentials" ]
 VOLUME [ "/app/instances" ]
 VOLUME [ "/app/logs" ]
 VOLUME [ "/app/maps" ]
+VOLUME [ "/app/authtokens" ]
 
 USER node
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,5 @@ services:
       - ./instances:/app/instances
       - ./credentials:/app/credentials
       - ./maps:/app/maps
+      - ./authtokens:/app/authtokens
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Pre-creates all state directories (`credentials`, `instances`, `logs`, `maps`, `authtokens`) with `node` ownership before `USER node` in the Dockerfile, fixing `EACCES` errors at runtime
- Adds missing `VOLUME ["/app/authtokens"]` declaration to the Dockerfile
- Adds `./authtokens:/app/authtokens` bind mount in `docker-compose.yml` for persistence

## Root cause

`authtokens` was added to `APP_STATE_DIR_NAMES` in `filesystemUtils.ts` but the Dockerfile was never updated. The other state dirs worked because they were bind-mounted from the host (bypassing the root-owned `/app` restriction), but `authtokens` had no mount and no pre-created directory with `node` ownership, causing the `EACCES: permission denied, mkdir '/app/authtokens'` error.

## Test plan

- [ ] Build the Docker image and confirm the container starts without `EACCES` errors
- [ ] Verify `/app/authtokens` is writable by the `node` user inside the container