### PR TITLE
fix: use provider stream type for TTS playback

### DIFF
--- a/src/discordTools/discordVoice.ts
+++ b/src/discordTools/discordVoice.ts
@@ -1,10 +1,4 @@
-import {
-    AudioPlayerStatus,
-    createAudioPlayer,
-    createAudioResource,
-    getVoiceConnection,
-    StreamType,
-} from '@discordjs/voice';
+import { AudioPlayerStatus, createAudioPlayer, createAudioResource, getVoiceConnection } from '@discordjs/voice';
 
 import { client } from '../index.js';
 import { getTTSProvider } from '../tts/getTTSProvider.js';
@@ -68,9 +62,10 @@ export async function sendDiscordVoiceMessage(guildId: string, text: string) {
 
     try {
         client.log('INFO', `Synthesizing TTS for guild ${guildId}: "${text.substring(0, 50)}..."`, 'info');
-        const stream = await getTTSProvider(guildId).synthesize(text, language, voice);
+        const provider = getTTSProvider(guildId);
+        const stream = await provider.synthesize(text, language, voice);
         client.log('INFO', `TTS synthesis complete for guild ${guildId}`, 'info');
-        const resource = createAudioResource(stream as any, { inputType: StreamType.OggOpus });
+        const resource = createAudioResource(stream as any, { inputType: provider.streamType });
 
         const player = getOrCreatePlayer(guildId);
         connection.subscribe(player);

--- a/src/tts/TTSProvider.ts
+++ b/src/tts/TTSProvider.ts
@@ -1,4 +1,5 @@
 import type { Readable } from 'node:stream';
+import type { StreamType } from '@discordjs/voice';
 
 export interface VoiceOption {
     label: string;
@@ -6,6 +7,7 @@ export interface VoiceOption {
 }
 
 export interface TTSProvider {
+    readonly streamType: StreamType;
     synthesize(text: string, language: string, voice: string): Promise<Readable>;
     getVoices(language: string): Promise<VoiceOption[]>;
 }

--- a/src/tts/providers/OddcastProvider.ts
+++ b/src/tts/providers/OddcastProvider.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream';
+import { StreamType } from '@discordjs/voice';
 import getStaticFilesStorage from '../../util/getStaticFilesStorage.js';
 import type { TTSProvider, VoiceOption } from '../TTSProvider.js';
 
@@ -21,6 +22,8 @@ const ACTOR_NAMES: Record<string, Record<string, string | null>> = {
 };
 
 export class OddcastProvider implements TTSProvider {
+    readonly streamType = StreamType.Arbitrary;
+
     async getVoices(language: string): Promise<VoiceOption[]> {
         const langActors = Actors[language];
         if (!langActors) return [];
@@ -50,6 +53,18 @@ export class OddcastProvider implements TTSProvider {
 
         const url = `https://cache-a.oddcast.com/tts/genC.php?EID=${params.EID}&LID=${params.LID}&VID=${params.VID}&TXT=${encodeURIComponent(text)}&EXT=mp3`;
         const response = await fetch(url);
+        if (!response.ok) {
+            const body = await response.text();
+            throw new Error(`Oddcast TTS request failed with ${response.status}: ${body.slice(0, 200)}`);
+        }
+        if (!response.body) {
+            throw new Error('Oddcast TTS response did not include an audio body');
+        }
+        const contentType = response.headers.get('content-type') ?? '';
+        if (contentType.includes('text/') || contentType.includes('json')) {
+            const body = await response.text();
+            throw new Error(`Oddcast TTS returned non-audio content (${contentType}): ${body.slice(0, 200)}`);
+        }
         return Readable.fromWeb(response.body as any);
     }
 }

--- a/src/tts/providers/PiperProvider.ts
+++ b/src/tts/providers/PiperProvider.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
 import { Readable } from 'node:stream';
+import { StreamType } from '@discordjs/voice';
 
 import { client } from '../../index.js';
 import type { TTSProvider, VoiceOption } from '../TTSProvider.js';
@@ -42,6 +43,8 @@ function fetchAllVoiceKeys(): Promise<string[]> {
 }
 
 export class PiperProvider implements TTSProvider {
+    readonly streamType = StreamType.OggOpus;
+
     async getVoices(language: string): Promise<VoiceOption[]> {
         let keys: string[];
         try {


### PR DESCRIPTION
## Summary
- add stream type metadata to TTS providers
- use provider-declared stream type when creating Discord audio resources
- validate Oddcast HTTP responses before queueing audio

## Verification
- pnpm build
- pnpm exec biome check src/discordTools/discordVoice.ts src/tts/TTSProvider.ts src/tts/providers/OddcastProvider.ts src/tts/providers/PiperProvider.ts